### PR TITLE
Create GitHub Action to cut new release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*' # Trigger on version tags
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Create Alfred Workflow
+        run: |
+          # Create a temporary directory for packaging
+          mkdir -p workflow
+          # Copy required files
+          cp icon.png info.plist run-script.py script-filter.py workflow/
+          # Create zip file with .alfredworkflow extension
+          cd workflow
+          zip -r ../GitHub-Models.alfredworkflow *
+          cd ..
+          
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: GitHub-Models.alfredworkflow
+          generate_release_notes: true
+          draft: false
+          prerelease: false


### PR DESCRIPTION
### New GitHub Actions Workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R34): Added a new workflow named "Create Release" that triggers on `push` events with version tags (`v*`). It packages files (`icon.png`, `info.plist`, `run-script.py`, and `script-filter.py`) into an Alfred Workflow (`.alfredworkflow`) and uploads it as part of a GitHub release using the `softprops/action-gh-release` action.

```shell
git tag v1.0.0 && git push origin v1.0.0
```