### PR TITLE
Remove non-existent `azure-ai` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ This project was heavily inspired by [`zeitlings/alfred-ollama`](https://github.
 
 - Alfred 5 with Powerpack
 - Python 3.9+
-  - Install `openai`, `azure-ai`, `azure-ai-inference`, and `azure-core` packages:
+  - Install `openai`, `azure-ai-inference`, and `azure-core` packages:
     ```bash
-    pip install openai azure-ai azure-ai-inference azure-core
+    pip install openai azure-ai-inference azure-core
     ```
     or use the `requirements.txt`:
     ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-openai>=1.0.0
-azure-ai>=1.0.0
-azure-ai-inference>=1.0.0
-azure-core>=1.0.0
+openai>=1.75.0
+azure-ai-inference>=1.0.0b9
+azure-core>=1.33.0


### PR DESCRIPTION
Fixes https://github.com/june1963/Alfred-GitHub-Models/issues/3

Thanks to @canuckjacq for the report!

Changes:

* Remove the `azure-ai` package from the list of required dependencies in README installation instructions
  * Both in the text and the example `pip install` command code snippet.
* Remove `azure-ai` package from the `requirements.txt` manifest file to be consistent with README installation instructions when installing dependencies from `requirements.txt`.
* Update all `requirements.txt` dependencies to specify the current versions of each required package from this point in time.